### PR TITLE
Add static pre-release job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -271,6 +271,68 @@ jobs:
           EXTRA_GHC: "/opt/ghc/${{ matrix.extra-ghc }}/bin/ghc-${{ matrix.extra-ghc }}"
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --lib-only -s lib-suite-extras --extra-hc ${{ env.EXTRA_GHC }}
 
+  build-alpine:
+    name: Build statically linked using alpine 
+    runs-on: "ubuntu-latest"
+    container: "alpine:3.19"
+    steps:
+      - name: Install extra dependencies
+        shell: sh
+        run: |
+          apk add bash curl sudo jq pkgconfig \
+          zlib-dev zlib-static binutils-gold curl \
+          gcc g++ gmp-dev libc-dev libffi-dev make \
+          musl-dev ncurses-dev perl tar xz
+
+      - uses: actions/checkout@v4
+
+      # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
+      - name: Manually supplied constraints/allow-newer
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo 'allow-newer:' ${ALLOWNEWER}  >> cabal.project.validate
+          echo 'constraints:' ${CONSTRAINTS} >> cabal.project.validate
+
+      #  See the following link for a breakdown of the following step
+      #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
+      - uses: actions/cache@v3
+        with:
+          # validate.sh uses a special build dir
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-*
+          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
+
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ env.GHC_FOR_RELEASE }}
+          cabal-version: latest # latest is mandatory for cabal-testsuite, see https://github.com/haskell/cabal/issues/8133
+
+      - name: Enable statically linked executables
+        run: |
+          echo 'executable-static: true' >> cabal.project.validate
+
+      - name: Build
+        run: sh validate.sh $FLAGS -s build
+
+      - name: Tar cabal head executable
+        run: |
+          CABAL_EXEC=$(cabal list-bin --builddir=dist-newstyle-validate-ghc-${{ env.GHC_FOR_RELEASE }} --project-file=cabal.project.validate cabal-install:exe:cabal)
+          # We have to tar the executable to preserve executable permissions
+          # see https://github.com/actions/upload-artifact/issues/38
+          export CABAL_EXEC_TAR="cabal-head-${{ runner.os }}-static-x86_64.tar.gz"
+          tar -czvf $CABAL_EXEC_TAR -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
+          echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> $GITHUB_ENV
+
+      - name: Upload cabal-install executable to workflow artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: cabal-${{ runner.os }}-static-x86_64
+          path: ${{ env.CABAL_EXEC_TAR }}
+
+
   # The previous jobs use a released version of cabal to build cabal HEAD itself
   # This one uses the cabal HEAD generated executable in the previous step
   # to build itself again, as sanity check
@@ -334,7 +396,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, dogfooding]
+    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
     - uses: actions/download-artifact@v3
@@ -359,6 +421,7 @@ jobs:
         files: |
           cabal-head-Windows-x86_64.tar.gz
           cabal-head-Linux-x86_64.tar.gz
+          cabal-head-Linux-static-x86_64.tar.gz
           cabal-head-macOS-x86_64.tar.gz
 
   # We use this job as a summary of the workflow
@@ -370,7 +433,7 @@ jobs:
     name: Validate post job
     runs-on: ubuntu-latest
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, dogfooding]
+    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
       - run: |


### PR DESCRIPTION
Add a job that builds a statically linked cabal-install executable, and make it available for pre-releases.

Resolves #9631.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

